### PR TITLE
Actions for the "Tweet Current Song" shortcut

### DIFF
--- a/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/GetCurrentSong.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/GetCurrentSong.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public func getCurrentSong() -> ActionWithOutput {
+    return Action(identifier: "is.workflow.actions.getcurrentsong", parameters: [:])
+}

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/GetText.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/GetText.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public func getText(_ text: String) -> ActionWithOutput {
+    return Action(
+        identifier: "is.workflow.actions.gettext",
+        parameters: ["WFTextActionText": withInterpolatedText(text)]
+    )
+}

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/Twitter.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/Actions/Twitter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public func tweet(showComposeSheet: Bool = true) -> Action {
+    return Action(
+        identifier: "is.workflow.actions.tweet",
+        parameters: [
+            "WFSocialActionShowComposeSheet": showComposeSheet,
+            ]
+    )
+}

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/Aggrandizement.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/Aggrandizement.swift
@@ -107,12 +107,14 @@ public enum Aggrandizement {
         case fileSize
         case fileExtension
         case number(Number)
+        case string(String)
 
         var propertyListValue: Any {
             switch self {
             case .fileSize: return "WFFileSizeProperty"
             case .fileExtension: return "WFFileExtensionProperty"
             case .number(let number): return number
+            case .string(let string): return string
             }
         }
     }

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/BuildShortcut.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/BuildShortcut.swift
@@ -39,12 +39,16 @@ public func exportShortcut(_ actionContainer: ActionContainer) -> Data {
     return try! PropertyListSerialization.data(fromPropertyList: buildShortcut(actionContainer), format: .binary, options: 0)
 }
 
+public func exportShortcut(_ shortcut: PropertyList) -> Data {
+    return try! PropertyListSerialization.data(fromPropertyList: shortcut, format: .binary, options: 0)
+}
+
 #if canImport(PlaygroundSupport)
 
 import PlaygroundSupport
 
 public func shareShortcut(_ shortcut: PropertyList, named name: String) {
-    let data = try! PropertyListSerialization.data(fromPropertyList: shortcut, format: .binary, options: 0)
+    let data = exportShortcut(shortcut)
     if let remoteView = PlaygroundPage.current.liveView as? PlaygroundRemoteLiveViewProxy {
         remoteView.send(.dictionary(["name": .string(name), "data": .data(data)]))
     }

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/InterpolatedText.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/InterpolatedText.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public func withInterpolatedText(_ string: String) -> Any {
+func withInterpolatedText(_ string: String) -> Any {
     var result = string
     var attachments = [String: Any]()
 

--- a/ShortcutsSwift.playgroundbook/Contents/Sources/InterpolatedText.swift
+++ b/ShortcutsSwift.playgroundbook/Contents/Sources/InterpolatedText.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func withInterpolatedText(_ string: String) -> Any {
+public func withInterpolatedText(_ string: String) -> Any {
     var result = string
     var attachments = [String: Any]()
 

--- a/ShortcutsSwift.xcodeproj/project.pbxproj
+++ b/ShortcutsSwift.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		98D33C2F21D3EFF100824660 /* Calculate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculate.swift; sourceTree = "<group>"; };
 		98D33C3321D4067C00824660 /* List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		FBDA8D4221DCCA9E00303374 /* AggrandizementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggrandizementTests.swift; sourceTree = "<group>"; };
+		FB7EE87321DC326B00C079C7 /* ShortcutsSwiftXcode.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = ShortcutsSwiftXcode.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +121,7 @@
 		5502FF7C21D0F06500CE7544 = {
 			isa = PBXGroup;
 			children = (
+				FB7EE87321DC326B00C079C7 /* ShortcutsSwiftXcode.playground */,
 				5502FFF221D0F58400CE7544 /* ShortcutsSwift.playgroundbook */,
 				5502FFED21D0F2AB00CE7544 /* Helpers */,
 				5502FFC021D0F1A300CE7544 /* Sources */,

--- a/ShortcutsSwift.xcodeproj/project.pbxproj
+++ b/ShortcutsSwift.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		98D33C2B21D3E34100824660 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D33C2A21D3E34100824660 /* Repeat.swift */; };
 		98D33C3021D3EFF100824660 /* Calculate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D33C2F21D3EFF100824660 /* Calculate.swift */; };
 		98D33C3421D4067C00824660 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D33C3321D4067C00824660 /* List.swift */; };
+		FB651C2721DE29D20029DAE6 /* Twitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB651C2621DE29D20029DAE6 /* Twitter.swift */; };
+		FB651C2921DE2A810029DAE6 /* GetText.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB651C2821DE2A810029DAE6 /* GetText.swift */; };
+		FB651C2B21DE2AAF0029DAE6 /* GetCurrentSong.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB651C2A21DE2AAF0029DAE6 /* GetCurrentSong.swift */; };
 		FBDA8D4321DCCA9E00303374 /* AggrandizementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBDA8D4221DCCA9E00303374 /* AggrandizementTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -85,6 +88,9 @@
 		98D33C2A21D3E34100824660 /* Repeat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repeat.swift; sourceTree = "<group>"; };
 		98D33C2F21D3EFF100824660 /* Calculate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calculate.swift; sourceTree = "<group>"; };
 		98D33C3321D4067C00824660 /* List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
+		FB651C2621DE29D20029DAE6 /* Twitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Twitter.swift; sourceTree = "<group>"; };
+		FB651C2821DE2A810029DAE6 /* GetText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetText.swift; sourceTree = "<group>"; };
+		FB651C2A21DE2AAF0029DAE6 /* GetCurrentSong.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentSong.swift; sourceTree = "<group>"; };
 		FBDA8D4221DCCA9E00303374 /* AggrandizementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggrandizementTests.swift; sourceTree = "<group>"; };
 		FB7EE87321DC326B00C079C7 /* ShortcutsSwiftXcode.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = ShortcutsSwiftXcode.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 /* End PBXFileReference section */
@@ -186,6 +192,9 @@
 				5502FFD021D0F1A400CE7544 /* Share.swift */,
 				5502FFD121D0F1A400CE7544 /* ShowResult.swift */,
 				98D33C2821D3DA0A00824660 /* SplitText.swift */,
+				FB651C2821DE2A810029DAE6 /* GetText.swift */,
+				FB651C2A21DE2AAF0029DAE6 /* GetCurrentSong.swift */,
+				FB651C2621DE29D20029DAE6 /* Twitter.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -334,11 +343,14 @@
 				5502FFEC21D0F29700CE7544 /* PlaygroundSupport.swift in Sources */,
 				5502FFEA21D0F1A400CE7544 /* Action.swift in Sources */,
 				83F8639821D15F7E00925583 /* Dictionary.swift in Sources */,
+				FB651C2921DE2A810029DAE6 /* GetText.swift in Sources */,
 				98D33C3421D4067C00824660 /* List.swift in Sources */,
 				98D33C2B21D3E34100824660 /* Repeat.swift in Sources */,
+				FB651C2721DE29D20029DAE6 /* Twitter.swift in Sources */,
 				5502FFE421D0F1A400CE7544 /* Share.swift in Sources */,
 				98D33C2921D3DA0A00824660 /* SplitText.swift in Sources */,
 				5502FFDD21D0F1A400CE7544 /* CopyToClipboard.swift in Sources */,
+				FB651C2B21DE2AAF0029DAE6 /* GetCurrentSong.swift in Sources */,
 				5502FFDF21D0F1A400CE7544 /* Comment.swift in Sources */,
 				5502FFE321D0F1A400CE7544 /* ChooseFromMenu.swift in Sources */,
 				5502FFD721D0F1A400CE7544 /* ShortcutShareViewController.swift in Sources */,

--- a/ShortcutsSwiftXcode.playground/Contents.swift
+++ b/ShortcutsSwiftXcode.playground/Contents.swift
@@ -17,17 +17,38 @@ public func saveShortcut(_ shortcut: PropertyList, name: String) {
     save(ext: "plist")
 }
 
-let batteryLevel = actionOutput()
-let shortcut = buildShortcut(
-    comment("This Shortcut was generated in Swift.") +
-        getBatteryLevel().savingOutput(to: batteryLevel) +
-        ifLessThan(20, ifTrue: (
-            setLowPowerMode(true) +
-                showResult("Your battery is at \(batteryLevel)%, you might want to charge it.")
-            ), ifFalse: (
-                showResult("Your battery is at \(batteryLevel)%, you're probably fine for now.")
-        ))
+public func getCurrentSong() -> ActionWithOutput {
+    return Action(identifier: "is.workflow.actions.getcurrentsong", parameters: [:])
+}
+
+public func getText(_ text: String) -> ActionWithOutput {
+    return Action(
+        identifier: "is.workflow.actions.gettext",
+        parameters: ["WFTextActionText": withInterpolatedText(text)]
+    )
+}
+
+public func tweet(showComposeSheet: Bool = true) -> Action {
+    return Action(
+        identifier: "is.workflow.actions.tweet",
+        parameters: [
+            "WFSocialActionShowComposeSheet": showComposeSheet,
+        ]
+    )
+}
+
+let song = actionOutput()
+let title = song.with(propertyName: .custom("Title"), userInfo: .string("title"))
+let artist = song.with(propertyName: .custom("Artist"), userInfo: .string("artist"))
+let albumArtwork = song.with(propertyName: .custom("Album Artwork"), userInfo: .string("artwork"))
+let tweetText = actionOutput(name: "Tweet")
+
+let shortcut = buildShortcut(comment("This Shortcut was generated in Swift.")
+    + getCurrentSong().savingOutput(to: song)
+    + getText("Listening to \(title) by \(artist) using Swift!").savingOutput(to: tweetText)
+    + list(["\(tweetText)", "\(albumArtwork)"])
+    + tweet()
 )
 
 //print(shortcut)
-saveShortcut(shortcut, name: "batery")
+saveShortcut(shortcut, name: "tweet song swift")

--- a/ShortcutsSwiftXcode.playground/Contents.swift
+++ b/ShortcutsSwiftXcode.playground/Contents.swift
@@ -1,42 +1,6 @@
 
 import ShortcutsSwift
 
-import Foundation
-import PlaygroundSupport
-public func saveShortcut(_ shortcut: PropertyList, name: String) {
-    let data = exportShortcut(shortcut)
-    func save(ext: String) {
-        let fileURL = URL(fileURLWithPath: "")
-            .appendingPathComponent(name)
-            .appendingPathExtension(ext)
-        try! data.write(to: fileURL)
-        print("open \(fileURL.deletingLastPathComponent().absoluteString.dropFirst(7))")
-    }
-    save(ext: "shortcut")
-    // TESTING
-    save(ext: "plist")
-}
-
-public func getCurrentSong() -> ActionWithOutput {
-    return Action(identifier: "is.workflow.actions.getcurrentsong", parameters: [:])
-}
-
-public func getText(_ text: String) -> ActionWithOutput {
-    return Action(
-        identifier: "is.workflow.actions.gettext",
-        parameters: ["WFTextActionText": withInterpolatedText(text)]
-    )
-}
-
-public func tweet(showComposeSheet: Bool = true) -> Action {
-    return Action(
-        identifier: "is.workflow.actions.tweet",
-        parameters: [
-            "WFSocialActionShowComposeSheet": showComposeSheet,
-        ]
-    )
-}
-
 let song = actionOutput()
 let title = song.with(propertyName: .custom("Title"), userInfo: .string("title"))
 let artist = song.with(propertyName: .custom("Artist"), userInfo: .string("artist"))

--- a/ShortcutsSwiftXcode.playground/Contents.swift
+++ b/ShortcutsSwiftXcode.playground/Contents.swift
@@ -1,0 +1,16 @@
+
+import ShortcutsSwift
+
+let batteryLevel = actionOutput()
+let shortcut = buildShortcut(
+    comment("This Shortcut was generated in Swift.") +
+        getBatteryLevel().savingOutput(to: batteryLevel) +
+        ifLessThan(20, ifTrue: (
+            setLowPowerMode(true) +
+                showResult("Your battery is at \(batteryLevel)%, you might want to charge it.")
+            ), ifFalse: (
+                showResult("Your battery is at \(batteryLevel)%, you're probably fine for now.")
+        ))
+)
+
+print(shortcut)

--- a/ShortcutsSwiftXcode.playground/Contents.swift
+++ b/ShortcutsSwiftXcode.playground/Contents.swift
@@ -1,6 +1,22 @@
 
 import ShortcutsSwift
 
+import Foundation
+import PlaygroundSupport
+public func saveShortcut(_ shortcut: PropertyList, name: String) {
+    let data = exportShortcut(shortcut)
+    func save(ext: String) {
+        let fileURL = URL(fileURLWithPath: "")
+            .appendingPathComponent(name)
+            .appendingPathExtension(ext)
+        try! data.write(to: fileURL)
+        print("open \(fileURL.deletingLastPathComponent().absoluteString.dropFirst(7))")
+    }
+    save(ext: "shortcut")
+    // TESTING
+    save(ext: "plist")
+}
+
 let batteryLevel = actionOutput()
 let shortcut = buildShortcut(
     comment("This Shortcut was generated in Swift.") +
@@ -13,4 +29,5 @@ let shortcut = buildShortcut(
         ))
 )
 
-print(shortcut)
+//print(shortcut)
+saveShortcut(shortcut, name: "batery")

--- a/ShortcutsSwiftXcode.playground/Sources/Support.swift
+++ b/ShortcutsSwiftXcode.playground/Sources/Support.swift
@@ -1,0 +1,17 @@
+import ShortcutsSwift
+import Foundation
+import PlaygroundSupport
+
+public func saveShortcut(_ shortcut: PropertyList, name: String) {
+    let data = exportShortcut(shortcut)
+    func save(ext: String) {
+        let fileURL = URL(fileURLWithPath: "")
+            .appendingPathComponent(name)
+            .appendingPathExtension(ext)
+        try! data.write(to: fileURL)
+        print("open \(fileURL.deletingLastPathComponent().absoluteString.dropFirst(7))")
+    }
+    save(ext: "shortcut")
+    // TESTING
+    save(ext: "plist")
+}

--- a/ShortcutsSwiftXcode.playground/contents.xcplayground
+++ b/ShortcutsSwiftXcode.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' executeOnSourceChanges='false'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Tests/AggrandizementTests.swift
+++ b/Tests/AggrandizementTests.swift
@@ -46,6 +46,15 @@ class AggrandizementTests: XCTestCase {
         )
     }
     
+    func testCustomStringProperty() {
+        let result = actionOutput()
+        let title = result.with(propertyName: .custom("Title"), userInfo: .string("title"))
+        _ = buildShortcut(
+            getBatteryLevel().savingOutput(to: result)
+                + showResult("Test Aggrandizements \(title)")
+        )
+    }
+    
     func testCoercion() {
         let result = actionOutput()
         let coercion = result.with(type: .article)


### PR DESCRIPTION
~~Branches from #19~~

To get familiar with the library I tried to replicate the "Tweet Current Song" shortcut:

<img src="https://user-images.githubusercontent.com/750912/50723463-4c46c000-10de-11e9-9795-217e10dd9d6c.PNG" width=200/>

To acomplish this I had to:

- Added an Xcode playground to develop on the Mac.
- case `.string` in `Aggrandizements` to get title, artist, etc from a song.
- `tweet` action
- `getCurrentSong` action
- `getText` action

With this I was able to replicate the shortcut with the following code:

```
    + getCurrentSong().savingOutput(to: song)
    + getText("Listening to \(title) by \(artist) using Swift!").savingOutput(to: tweetText)
    + list(["\(tweetText)", "\(albumArtwork)"])
    + tweet()
```

The plist is the same as the one created by the App except the content of the `list` action. 

<img width="1209" alt="screen shot 2019-01-05 at 11 43 44" src="https://user-images.githubusercontent.com/750912/50723528-6503a580-10df-11e9-986b-867fd969a8b1.png">

The implementation of the list action assumes `[String]` but seems like the app supports different types. It works with this example but we may want to look into it to make other uses posible. 